### PR TITLE
feat: use readonly in return value type

### DIFF
--- a/src/use-is-mounted-ref.ts
+++ b/src/use-is-mounted-ref.ts
@@ -1,12 +1,14 @@
-import { useRef, useEffect, MutableRefObject } from 'react';
+import { useRef, useEffect } from 'react';
 
-function useIsMountedRef(): MutableRefObject<boolean> {
+function useIsMountedRef(): { readonly current: boolean } {
   const isMountedRef = useRef(false);
 
   useEffect(() => {
     isMountedRef.current = true;
 
-    return () => (isMountedRef.current = false);
+    return () => {
+      isMountedRef.current = false;
+    };
   }, []);
 
   return isMountedRef;


### PR DESCRIPTION

add readonly in return type to disable this pattern
```ts
  const isMountedRef = useIsMountedRef();

  // in some callback
    isMountedRef.current = false;
```